### PR TITLE
fix dualmc edge case

### DIFF
--- a/src/cudualmc.cu
+++ b/src/cudualmc.cu
@@ -779,8 +779,8 @@ namespace cudualmc
       Scalar d = ds[dim];
       // dmc.used_cell_mc_vert[3 * used_index + dim] = 0;
 
-      bool entering = d0 <= iso && d >= iso;
-      bool exiting = d <= iso && d0 >= iso;
+      bool entering = d0 < iso && d >= iso;
+      bool exiting = d < iso && d0 >= iso;
       if (entering || exiting)
       {
         IndexType id = first++;


### PR DESCRIPTION
This fixed edge case causes incorrect cell classification and leads to incorrect quads.
(maybe it also happens for regular MC?)