### PR TITLE
ROCm Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,29 @@ The algorithms have been rigorously tested on an NVIDIA RTX 4090 GPU. Each algor
 | VRAM / G | 3.07 | 4.07 | 0.59 | 0.45 |
 | Time / ms | 49.10 | 65.35 | 2.55 | 2.78 |
 
+# ROCm Support (using AMD Docker ROCm build environment)
+
+- install docker
+- `git clone` this repository
+- Build from source with ROCM=1 flag as follows;
+
+```
+docker run -it \
+    --cap-add=SYS_PTRACE \
+    --device=/dev/kfd \
+    --device=/dev/dri \
+    --group-add video \
+    --shm-size 8G \
+    --volume $PWD:/ \
+    --network host \
+    rocm/pytorch:rocm7.1_ubuntu24.04_py3.12_pytorch_release_2.7.1
+
+for file in src/*; do echo "$file"; [ -f "$file" ] && hipify-perl "$file" --inplace; done
+
+export FORCE_CUDA=1; export ROCM=1; python setup.py sdist bdist_wheel
+# output is in /dist
+# pip install dist/<filename>
+```
 
 # Citation
 If you find this repository useful, please cite the following paper:

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,6 @@ from torch.utils.cpp_extension import (
     CUDAExtension,
 )
 
-
 def get_extensions():
     """Refer to torchvision."""
 
@@ -39,6 +38,20 @@ def get_extensions():
 
     sources = [s for s in sources]
     include_dirs = ["src"]
+
+    if os.getenv(
+        "ROCM", "0"
+    ) == "1":
+        # Optional: Define ROCM_PATH if it's not set in your environment
+        ROCM_PATH = os.environ.get('ROCM_PATH', '/opt/rocm')
+
+        # Define paths for HIP include and library directories
+        hip_include_dir = os.path.join(ROCM_PATH, 'include')
+        hip_library_dir = os.path.join(ROCM_PATH, 'lib')
+
+        include_dirs = [hip_include_dir, "src"]
+
+
     print("sources:", sources)
 
     ext_modules = [
@@ -50,6 +63,23 @@ def get_extensions():
             extra_compile_args=extra_compile_args,
         )
     ]
+
+    if os.getenv(
+        "ROCM", "0"
+    ) == "1":
+        ext_modules = [
+            extension(
+                "diso._C",
+                sources,
+                include_dirs=include_dirs,
+                define_macros=define_macros,
+                library_dirs=[hip_library_dir],
+                libraries=['amdhip64'],
+                runtime_library_dirs=[hip_library_dir],
+                extra_compile_args=extra_compile_args,
+            )
+        ]
+
     return ext_modules
 
 setup(


### PR DESCRIPTION
Builds this package for AMD cards.

Testing requires an AMD card. Tested with Fedora 43 and Radeon RX 7900 XTX. After installing the package with pip I could successfully run the test example.

No original code touched, sits behind a build flag and uses [AMD's Hip API](https://rocm.docs.amd.com/projects/HIP/en/latest/what_is_hip.html) to re-code the source.

Library linking is assumed to use the docker rocm image's /opt/rocm

Future update would be to make using docker optional and instead pass ROCM_HOME var to the setup.py